### PR TITLE
Fix bug where "and" clause always fails (use or instead of alt). 0.1-a…

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.akiel/datomic-spec "0.1-alpha1"
+(defproject org.clojars.akiel/datomic-spec "0.1-alpha2"
   :description "Specs for Datomic"
   :url "https://github.com/alexanderkiel/datomic-spec"
   :license {:name "Eclipse Public License"

--- a/src/datomic_spec/core.clj
+++ b/src/datomic_spec/core.clj
@@ -248,13 +248,13 @@
 (s/def ::or-clause
   (s/cat :src-var (s/? ::src-var)
          :op #{'or}
-         :clauses (s/+ (s/alt :clause ::clause :and-clause ::and-clause))))
+         :clauses (s/+ (s/or :clause ::clause :and-clause ::and-clause))))
 
 (s/def ::or-join-clause
   (s/cat :src-var (s/? ::src-var)
          :op #{'or-join}
          :rule-vars ::rule-vars
-         :clauses (s/+ (s/alt :clause ::clause :and-clause ::and-clause))))
+         :clauses (s/+ (s/or :clause ::clause :and-clause ::and-clause))))
 
 (s/def ::rule-vars
   (s/alt :vars (s/+ ::variable)


### PR DESCRIPTION
…lpha2
